### PR TITLE
Fixed the import Issue explained in #14

### DIFF
--- a/LTServer.py
+++ b/LTServer.py
@@ -1,5 +1,10 @@
 import sublime
-import urllib
+try:
+    from urlparse import urlencode
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.parse import urlencode
+    from urllib.request import urlopen
 
 import sys
 import os
@@ -31,19 +36,19 @@ def _post(server, payload):
 		return _post_ST3(server, payload)
 
 def _post_ST2(server, payload):
-	data = urllib.urlencode(payload)
+	data = urlencode(payload)
 	try:
-		content = urllib.urlopen(server, data).read()
+		content = urlopen(server, data).read()
 	except IOError:
 		return None
 	else:
 		return content
 
 def _post_ST3(server, payload):
-	data = urllib.parse.urlencode(payload)
+	data = urlencode(payload)
 	data = data.encode('utf8')
 	try:
-		content = urllib.request.urlopen(server, data).read()
+		content = urlopen(server, data).read()
 	except IOError:
 		return None
 	else:


### PR DESCRIPTION
#14 describes an issue with urllib. It is caused, because some versions of Python can not import submodules indirectly. Not really sure why. I made the imports explicit, and it seems to work. I could not test it with sublime text 2. So it might be nice, if someone could check before merging. But the current build of Sublime Text 3 works.