### PR TITLE
Fix "Deactivate Rule" not working

### DIFF
--- a/LanguageTool.py
+++ b/LanguageTool.py
@@ -478,7 +478,7 @@ class DeactivateRuleCommand(sublime_plugin.TextCommand):
             ignored.append(rule)
             ignoredProblems = [p for p in problems if p['rule'] == rule['id']]
             for p in ignoredProblems:
-                ignore_problem(p, v, self, edit)
+                ignore_problem(p, v, edit)
             problems = [p for p in problems if p['rule'] != rule['id']]
             v.run_command("goto_next_language_problem")
             save_ignored_rules(ignored)


### PR DESCRIPTION
This PR fixes the following error:

```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 1088, in run_
    return self.run(edit)
  File "/Users/мояимя/Library/Application Support/Sublime Text 3/Packages/languagetool-sublime/LanguageTool.py", line 487, in run
    ignore_problem(p, v, self, edit)
TypeError: ignore_problem() takes 3 positional arguments but 4 were given
```