### PR TITLE
Get "Start Local Server" working with LanguageTool 4.x

### DIFF
--- a/LanguageTool.py
+++ b/LanguageTool.py
@@ -237,7 +237,7 @@ class startLanguageToolServerCommand(sublime_plugin.TextCommand):
 
         sublime.status_message('Starting local LanguageTool server ...')
 
-        cmd = ['java', '-jar', jar_path, '-t']
+        cmd = ['java', '-cp', jar_path, 'org.languagetool.server.HTTPServer', '--port', '8081']
 
         if sublime.platform() == "windows":
             p = subprocess.Popen(


### PR DESCRIPTION
The default behavior of `languagetool-server.jar` has changed to start a HTTPS server, not a HTTP one. This PR changes the arguments passed to `java` to revert this back to the old behavior.

This PR fixes #29.