### PR TITLE
Fix issue #41: no text in the LanguageTool panel

### DIFF
--- a/LanguageTool.py
+++ b/LanguageTool.py
@@ -102,7 +102,7 @@ class setLanguageToolPanelTextCommand(sublime_plugin.TextCommand):
         pt.settings().set("wrap_width", 0)
         pt.settings().set("word_wrap", True)
         pt.set_read_only(False)
-        pt.insert(edit, pt.size(), str)
+        pt.run_command('insert', {'characters': str})
         window.run_command("show_panel", {"panel": "output.languagetool"})
 
 


### PR DESCRIPTION
In sublime 4, no text gets displayed in the LanguageTool panel.

The issue seems to be that in setLanguageToolPanelTextCommand() the Edit object isn't for the languagetool output view so the call to insert() fails. The command "insert" creates a new edit context for the correct view.